### PR TITLE
chore: update namespace syntax

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,6 +3,9 @@ name: Build on Nightly
 on:
   pull_request:
     branches: [ master ]
+  push:
+    branches:
+      - 'main'
   # Also runs daily so we get a notification if a change in Flix breaks this
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,28 @@
+name: Build on Nightly
+
+on:
+  pull_request:
+    branches: [ master ]
+  # Also runs daily so we get a notification if a change in Flix breaks this
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  build-nightly:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v2.5.0
+        with:
+          java-version: 17
+          distribution: zulu
+      - run: |
+          # download today's or yesterday's Flix JAR
+          today=$(date -d today +%Y-%m-%d)
+          yesterday=$(date -d yesterday +%Y-%m-%d)
+          today_url="https://flix.dev/nightly/flix-${today}.jar"
+          yesterday_url="https://flix.dev/nightly/flix-${yesterday}.jar"
+          curl -L -f "${today_url}" > flix.jar || curl -L -f "${yesterday_url}" > flix.jar
+
+          # run tests
+          java -jar flix.jar test

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Convenient wrapper of ANSI methods [listed
 here](https://en.wikipedia.org/wiki/ANSI_escape_code#CSI_(Control_Sequence_Introducer)_sequences).
 Commands are output with `Console.print` but raw strings can also be accessed in
-the `Terminal/String` namespace.
+the `Terminal.String` namespace.
 
 # Flix version
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 Convenient wrapper of ANSI methods [listed
 here](https://en.wikipedia.org/wiki/ANSI_escape_code#CSI_(Control_Sequence_Introducer)_sequences).
-Commands are output with `print` but raw strings can also be accessed in
+Commands are output with `Console.print` but raw strings can also be accessed in
 the `Terminal/String` namespace.
 
 # Flix version
 
-Flix 0.33.0+ [from this commit](https://github.com/flix/flix/commit/4ee8d86c4e0420c19a5ffc38bc7edd881ed107cd)
+Flix 0.34.0+ (nightly 2022-12-18)
 
 # License
 

--- a/flix.toml
+++ b/flix.toml
@@ -1,0 +1,7 @@
+[package]
+name        = "Flix-ANSI-Terminal"
+description = "An API for ANSI terminal operations"
+version     = "1.2.0"
+flix        = "0.35.0"
+license     = "Apache-2.0"
+authors     = ["Jonathan Lindegaard Starup"]

--- a/src/Terminal.flix
+++ b/src/Terminal.flix
@@ -197,7 +197,7 @@ namespace Terminal {
     }
 
     def output(x: s): Unit \ IO with ToString[s] =
-        print(x)
+        Console.print(x)
 
     def csi(s: String): String =
         let escapeByte = "\u001B";

--- a/src/Terminal.flix
+++ b/src/Terminal.flix
@@ -15,7 +15,7 @@
 // For more information see here
 // https://en.wikipedia.org/wiki/ANSI_escape_code
 
-namespace Terminal {
+mod Terminal {
 
     ///
     /// Moves the cursor `n` cells up. If the cursor is / already at the edge of
@@ -23,7 +23,7 @@ namespace Terminal {
     ///
     pub def cursorUp(n: Int32): Unit \ IO =
         if (n <= 0) () else
-        output(Terminal/String.cursorUp(n))
+        output(Terminal.String.cursorUp(n))
 
     ///
     /// Moves the cursor `n` cells down. If the cursor is already at the edge of
@@ -31,7 +31,7 @@ namespace Terminal {
     ///
     pub def cursorDown(n: Int32): Unit \ IO =
         if (n <= 0) () else
-        output(Terminal/String.cursorDown(n))
+        output(Terminal.String.cursorDown(n))
 
     ///
     /// Moves the cursor `n` cells forward. If the cursor is already at the edge of
@@ -39,7 +39,7 @@ namespace Terminal {
     ///
     pub def cursorForward(n: Int32): Unit \ IO =
         if (n <= 0) () else
-        output(Terminal/String.cursorForward(n))
+        output(Terminal.String.cursorForward(n))
 
     ///
     /// Moves the cursor `n` cells back. If the cursor is already at the edge of
@@ -47,7 +47,7 @@ namespace Terminal {
     ///
     pub def cursorBack(n: Int32): Unit \ IO =
         if (n <= 0) () else
-        output(Terminal/String.cursorBack(n))
+        output(Terminal.String.cursorBack(n))
 
     ///
     /// Moves the cursor to row `n`, column `m`, starting at `(0, 0)`.
@@ -55,45 +55,45 @@ namespace Terminal {
     pub def cursorTo(row: {row = Int32}, column: Int32): Unit \ IO =
         if (row.row < 0 or column < 0) () else
         if (row.row == 0 and column == 0) () else
-        output(Terminal/String.cursorTo(row, column))
+        output(Terminal.String.cursorTo(row, column))
 
     ///
     /// Clear from cursor (inclusive) to end of screen.
     ///
     pub def clearScreenAfterCursor(): Unit \ IO =
-        output(Terminal/String.clearScreenAfterCursor())
+        output(Terminal.String.clearScreenAfterCursor())
 
     ///
     /// Clear from cursor (inclusive) to beginning of the screen.
     ///
     pub def clearScreenBeforeCursor(): Unit \ IO =
-        output(Terminal/String.clearScreenBeforeCursor())
+        output(Terminal.String.clearScreenBeforeCursor())
 
     ///
     /// Clear entire screen and moves cursor to upper left.
     ///
     pub def clearScreenAndReset(): Unit \ IO =
-        output(Terminal/String.clearScreenAndReset())
+        output(Terminal.String.clearScreenAndReset())
 
     ///
     /// Clear from cursor (inclusive) to the end of the line.
     /// Cursor position does not change.
     ///
     pub def clearLineAfterCursor(): Unit \ IO =
-        output(Terminal/String.clearLineAfterCursor())
+        output(Terminal.String.clearLineAfterCursor())
 
     ///
     /// Clear from cursor (inclusive) to beginning of the line.
     /// Cursor position does not change.
     ///
     pub def clearLineBeforeCursor(): Unit \ IO =
-        output(Terminal/String.clearLineBeforeCursor())
+        output(Terminal.String.clearLineBeforeCursor())
 
     ///
     /// Clear entire line. Cursor position does not change.
     ///
     pub def clearLine(): Unit \ IO =
-        output(Terminal/String.clearLine())
+        output(Terminal.String.clearLine())
 
     ///
     /// Saves the current cursor position for later restoration.
@@ -101,15 +101,15 @@ namespace Terminal {
     /// when printing newlines at the bottom of the terminal.
     ///
     pub def saveCursor(): Unit \ IO =
-        output(Terminal/String.saveCursor())
+        output(Terminal.String.saveCursor())
 
     ///
     /// Restores the previously saved cursor.
     ///
     pub def restoreCursor(): Unit \ IO =
-        output(Terminal/String.restoreCursor())
+        output(Terminal.String.restoreCursor())
 
-    namespace String {
+    mod String {
         use Terminal.csi;
 
         ///

--- a/test/TestTerminal.flix
+++ b/test/TestTerminal.flix
@@ -1,10 +1,10 @@
 namespace TestTerminal {
 
     def output(x: s): Unit \ IO with ToString[s] =
-        print(x)
+        Console.print(x)
 
     def outputLine(x: s): Unit \ IO with ToString[s] =
-        println(x)
+        Console.println(x)
 
     def sleep(millis: Int64): Unit \ IO =
         import static java.lang.Thread.sleep(Int64): Unit \ IO;

--- a/test/TestTerminal.flix
+++ b/test/TestTerminal.flix
@@ -1,4 +1,4 @@
-namespace TestTerminal {
+mod TestTerminal {
 
     def output(x: s): Unit \ IO with ToString[s] =
         Console.print(x)


### PR DESCRIPTION
Renames namespace keyword to mod and uses dot syntax for namespace separation.